### PR TITLE
feat(routing): add conditional layout rendering for standalone pages

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1,11 +1,24 @@
 <script setup lang="ts">
 import Layout from './components/Layout.vue'
+import { useRoute } from 'vue-router'
+import { computed } from 'vue'
+
+const route = useRoute()
+
+// Define routes that should not use the layout (standalone pages)
+const standaloneRoutes = ['ProjectDetail']
+
+// Check if current route should use layout
+const shouldUseLayout = computed(() => {
+  return !standaloneRoutes.includes(route.name as string)
+})
 </script>
 
 <template>
-  <Layout>
+  <Layout v-if="shouldUseLayout">
     <router-view />
   </Layout>
+  <router-view v-else />
 </template>
 
 <style>

--- a/src/pages/ProjectDetail.vue
+++ b/src/pages/ProjectDetail.vue
@@ -174,8 +174,8 @@ const goBack = () => {
 
 <style scoped>
 .project-detail {
-  min-height: calc(100vh - 160px); /* Account for navbar and footer */
-  padding: 2rem 0;
+  min-height: 100vh; /* Full viewport height for standalone page */
+  padding: 0;
   background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
   color: white;
 }
@@ -183,7 +183,7 @@ const goBack = () => {
 .container {
   max-width: 1200px;
   margin: 0 auto;
-  padding: 0 1rem;
+  padding: 3rem 1rem 2rem 1rem; /* Increased top padding for standalone page */
 }
 
 .project-header {


### PR DESCRIPTION
Add logic to exclude ProjectDetail page from main layout and adjust its styling to be full viewport height. This allows for standalone pages that don't need the common layout structure.